### PR TITLE
Fixed a bug and optimised next multiple finder

### DIFF
--- a/src/LuhnMod16.php
+++ b/src/LuhnMod16.php
@@ -34,10 +34,12 @@ class LuhnMod16
             if ($i % 2 !== 0) {
                 // Double it
                 $doubled = $character_list[$i] * 2;
+
                 // Convert it to hexadecimal
                 $hexed = dechex($doubled);
-                // If it's still a number (not a hex 'letter')
-                if (ctype_digit($hexed)) {
+
+                // If it's still a number (not a hex 'letter'), note casting to string, as ctype_digit accepts ascii codes as well
+                if (ctype_digit((string) $hexed)) {
                     $character_list[$i] = array_sum(str_split($hexed)); // Store it
                 }
             }
@@ -46,15 +48,13 @@ class LuhnMod16
         // Add them all up
         $total = array_sum($character_list);
 
-        // Find the next multiple of 16
-        $next_multiple_of_n = round(($total + 16 / 2) / 16) * 16;
-
-        // Get the difference
-        $difference = $next_multiple_of_n - $total;
+        // Get the difference between next multiple of 16 and the sum
+        $difference = ceil($total / 16) * 16 - $total;
 
         // Convert to hex
         $hex = dechex($difference);
 
-        return $hex;
+        // uppercase it
+        return strtoupper($hex);
     }
 }

--- a/tests/LuhnMod16Test.php
+++ b/tests/LuhnMod16Test.php
@@ -9,8 +9,24 @@ class LuhnModNTest extends \PHPUnit\Framework\TestCase
      */
     public function testCalculatesCorrectly()
     {
-        $test_value = '0B012722900021AC35B2';
-        $checksum = \LuhnMod16\LuhnMod16::calculate($test_value);
-        $this->assertEquals($checksum, '1');
+        $data = [
+            ['check' => '5', 'string' => '0A0417347000000005B2'],
+            ['check' => '1', 'string' => '0A0417347000000005CB'],
+            ['check' => 'F', 'string' => '0A0417347000000005CC'],
+            ['check' => 'B', 'string' => '0A0417347000000005CD'],
+            ['check' => 'A', 'string' => '0A0417347000000005CE'],
+            ['check' => '9', 'string' => '0A0417347000000005CF'],
+            ['check' => '7', 'string' => '0A0417347000000005D0'],
+            ['check' => '5', 'string' => '0A0417347000000005D1'],
+            ['check' => '3', 'string' => '0A0417347000000005D2'],
+            ['check' => '1', 'string' => '0A0417347000000005D3'],
+            ['check' => 'F', 'string' => '0A0417347000000005D4'],
+            ['check' => '2', 'string' => '0A0417347000000005D5'],
+            ['check' => '1', 'string' => '0A0417347000000005D6'],
+        ];
+        
+        foreach($data as $row) {
+            $this->assertEquals($row['check'], \LuhnMod16\LuhnMod16::calculate($row['string']));
+        }
     }
 }


### PR DESCRIPTION
Found a bug with ctype check - as it also accepts integers and checks if the ascii character of that code is a number it was giving false positives for some numbers, also the finding next multiple could be simplified. Added more test values to your test as well